### PR TITLE
Added testcase to check if tar is installed in the container image.

### DIFF
--- a/containersQa/120_testTarInstalled.sh
+++ b/containersQa/120_testTarInstalled.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+set -o pipefail
+
+## resolve folder of this script, following all symlinks,
+## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+readonly SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+
+source $SCRIPT_DIR/testlib.bash
+
+parseArguments "$@"
+processArguments
+setup
+testTarIsInstalled 2>&1| tee  $REPORT_FILE # then check the 8 or 11 in it against some NVR

--- a/containersQa/testlib.bash
+++ b/containersQa/testlib.bash
@@ -861,6 +861,11 @@ function checkOtherUserWorks() {
   test -z "$OUTPUT"
 }
 
+# This test is added to check that tar is installed in all Openjdk images.
+#  https://issues.redhat.com/browse/OPENJDK-2588
+function testTarIsInstalled() {
+  runOnBaseDir  tar --version
+}
 #  SECTION FOR BUILDING CONTAINER IMAGES FOR TEST. 
 #   Ultimately these may be broken out to seperate file.
 


### PR DESCRIPTION
Testcase to test the presents of 'tar' in the container image.
Related to ticket: https://issues.redhat.com/browse/OPENJDK-2588

Ran locally against a full image, an old runtime image to prove it fails and the current runtime image to prove it passes.