### PR TITLE
Fix for 212 and 213 failures due to test artifact compile issue with JDK 21.

### DIFF
--- a/containersQa/testlib.bash
+++ b/containersQa/testlib.bash
@@ -545,6 +545,12 @@ function s2iLocal() {
     else
       cat $DF.orig | sed "s;/s2i/run;/s2i/run $ADDS;g;" > $DF.nw1
     fi
+    if [ "x$COMMIT_HASH" != x ] ; then
+      #cd into the source folder and checkout the koji source based on the known commit
+      pushd upload/src
+         git checkout 048d32f1a311ae97c87bd885dd17cac6dddb5f94
+      popd
+    fi
     cat $DF.nw1 | tee $DF
     buildFileWithHash $DF
   popd
@@ -625,6 +631,7 @@ function s2iLocaMultiModWorksNoMain() {
   REPO="https://github.com/judovana/jenkins-scm-koji-plugin.git" 
   NAME="multimod_nomain"
   ADDS=""
+  COMMIT_HASH="048d32f1a311ae97c87bd885dd17cac6dddb5f94"
   JENKINS_BUILD="yes"
   s2iLocal
 }
@@ -637,6 +644,7 @@ function s2iLocaMultiModWorksMain() {
   REPO="https://github.com/judovana/jenkins-scm-koji-plugin.git" 
   NAME="multimod_main"
   ADDS=""
+  COMMIT_HASH="048d32f1a311ae97c87bd885dd17cac6dddb5f94"
   JENKINS_BUILD="yes"
   s2iLocal 
 }


### PR DESCRIPTION
The solution is to lock the test to a specific commit of the jenkins-scm-koji-plugin repo build for the test artifact.
Repo:
https://github.com/judovana/jenkins-scm-koji-plugin
Commit:
048d32f1a311ae97c87bd885dd17cac6dddb5f94
https://github.com/judovana/jenkins-scm-koji-plugin/commit/048d32f1a311ae97c87bd885dd17cac6dddb5f94

Tested running on a Rhel 9 image against a JDK 21 image and JDK 8 image.