### PR TITLE
Added basic crypto algorithm and provider listing tests

### DIFF
--- a/containersQa/700_listCryptoAlgorithms.sh
+++ b/containersQa/700_listCryptoAlgorithms.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ex
+set -o pipefail
+
+## resolve folder of this script, following all symlinks,
+## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+readonly SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+
+source $SCRIPT_DIR/testlib.bash
+
+parseArguments "$@"
+processArguments
+setup
+setAlgorithmTestsUrlVars
+listCryptoAlgorithms 2>&1| tee $REPORT_FILE

--- a/containersQa/701_listCryptoAlgorithmsWithFipsSet.sh
+++ b/containersQa/701_listCryptoAlgorithmsWithFipsSet.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ex
+set -o pipefail
+
+## resolve folder of this script, following all symlinks,
+## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+readonly SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+
+source $SCRIPT_DIR/testlib.bash
+
+parseArguments "$@"
+processArguments
+setup
+setAlgorithmTestsUrlVars
+listCryptoAlgorithmsWithFipsSet 2>&1| tee $REPORT_FILE

--- a/containersQa/702_listCryptoProviders.sh
+++ b/containersQa/702_listCryptoProviders.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ex
+set -o pipefail
+
+## resolve folder of this script, following all symlinks,
+## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+readonly SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+
+source $SCRIPT_DIR/testlib.bash
+
+parseArguments "$@"
+processArguments
+setup
+setAlgorithmTestsUrlVars
+listCryptoProviders 2>&1| tee $REPORT_FILE

--- a/containersQa/703_listCryptoProvidersWithFipsSet.sh
+++ b/containersQa/703_listCryptoProvidersWithFipsSet.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -ex
+set -o pipefail
+
+## resolve folder of this script, following all symlinks,
+## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+readonly SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+
+source $SCRIPT_DIR/testlib.bash
+
+parseArguments "$@"
+processArguments
+setup
+setAlgorithmTestsUrlVars
+listCryptoProvidersWithFipsSet 2>&1| tee $REPORT_FILE

--- a/containersQa/testlib.bash
+++ b/containersQa/testlib.bash
@@ -182,6 +182,10 @@ function runOnBaseDirBashOtherUser() {
   $PD_PROVIDER run -i -u 12324 $HASH bash -c "$1"
 }
 
+function runOnBaseDirBashRootUser() {
+  $PD_PROVIDER run -i -u root $HASH bash -c "$1"
+}
+
 function lsLUsrLibJvm() {
   runOnBaseDir  ls -l /usr/lib/jvm
 }
@@ -924,4 +928,37 @@ function newUserCheck() {
 EOF
     $PD_PROVIDER build -f $podmanfile .
 
+}
+
+function setAlgorithmTestsUrlVars {
+  checkAlgorithmsUrl="https://raw.githubusercontent.com/rh-openjdk/jtreg-buffer/ea3c06d3d67cb05/test/reproducers/checkAlgorithms/CheckAlgorithms.java"
+  cipherListUrl="https://raw.githubusercontent.com/rh-openjdk/jtreg-buffer/ea3c06d3d67cb05/test/reproducers/1906862/CipherList.java"
+}
+
+function listCryptoAlgorithms() {
+  skipIfJreExecution
+  # curl downloads the needed test files inside of the container, compiles them and runs them
+  runOnBaseDirBash "cd /tmp && curl -O $checkAlgorithmsUrl && curl -O $cipherListUrl && \
+                    javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list algorithms"
+}
+
+function listCryptoAlgorithmsWithFipsSet() {
+  skipIfJreExecution
+  # curl downloads the needed test files inside of the container, compiles them and runs them
+  runOnBaseDirBashRootUser "update-crypto-policies --set FIPS && cd /tmp && curl -O $checkAlgorithmsUrl && curl -O $cipherListUrl && \
+                            javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list algorithms"
+}
+
+function listCryptoProviders() {
+  skipIfJreExecution
+  # curl downloads the needed test files inside of the container, compiles them and runs them
+  runOnBaseDirBash "cd /tmp && curl -O $checkAlgorithmsUrl && curl -O $cipherListUrl && \
+                    javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list providers"
+}
+
+function listCryptoProvidersWithFipsSet() {
+  skipIfJreExecution
+  # curl downloads the needed test files inside of the container, compiles them and runs them
+  runOnBaseDirBashRootUser "update-crypto-policies --set FIPS && cd /tmp && curl -O $checkAlgorithmsUrl && curl -O $cipherListUrl && \
+                            javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list providers"
 }


### PR DESCRIPTION
I added four separate tests:

- test listing available crypto algorithms
- test listing available crypto algorithms, but running `update-crypto-policies --set FIPS` before in the container (on my non-FIPS system, it actually prints different results)
- test listing available crypto providers
- test listing available crypto providers with `update-crypto-policies --set FIPS`

These tests just list the algorithms/providers, no actual "testing" is done, so they should all pass unless something nasty happens.