### PR TITLE
Making the FIPS tests' output in report.txt more clear/readable

### DIFF
--- a/containersQa/702_listCryptoAlgorithms.sh
+++ b/containersQa/702_listCryptoAlgorithms.sh
@@ -19,4 +19,4 @@ parseArguments "$@"
 processArguments
 setup
 setupAlgorithmTesting
-listCryptoAlgorithms 2>&1| tee $REPORT_FILE
+listCryptoAlgorithms

--- a/containersQa/703_listCryptoProviders.sh
+++ b/containersQa/703_listCryptoProviders.sh
@@ -19,4 +19,4 @@ parseArguments "$@"
 processArguments
 setup
 setupAlgorithmTesting
-listCryptoProviders 2>&1| tee $REPORT_FILE
+listCryptoProviders

--- a/containersQa/testlib.bash
+++ b/containersQa/testlib.bash
@@ -991,21 +991,17 @@ function validateManualSettingFipsWithNoCrash() {
 function listCryptoAlgorithms() {
   skipIfJreExecution
   set +x
-
   commandAlgorithms="echo '$checkAlgorithmsCode' > /tmp/CheckAlgorithms.java && echo '$cipherListCode' > /tmp/CipherList.java && javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list algorithms"
-  runOnBaseDirBash "$commandAlgorithms"
-  echo "runOnBaseDirBash $commandAlgorithms" >> $REPORT_DIR/global-stdouterr.log
-
+  runOnBaseDirBash "$commandAlgorithms" 2>&1| tee $REPORT_FILE
+  echo "runOnBaseDirBash $commandAlgorithms"
   set -x
 }
 
 function listCryptoProviders() {
   skipIfJreExecution
   set +x
-
   commandProviders="echo '$checkAlgorithmsCode' > /tmp/CheckAlgorithms.java && echo '$cipherListCode' > /tmp/CipherList.java && javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list providers"
-  runOnBaseDirBash "$commandProviders"
-  echo "runOnBaseDirBash $commandProviders" >> $REPORT_DIR/global-stdouterr.log
-
+  runOnBaseDirBash "$commandProviders" 2>&1| tee $REPORT_FILE
+  echo "runOnBaseDirBash $commandProviders"
   set -x
 }

--- a/containersQa/testlib.bash
+++ b/containersQa/testlib.bash
@@ -991,15 +991,21 @@ function validateManualSettingFipsWithNoCrash() {
 function listCryptoAlgorithms() {
   skipIfJreExecution
   set +x
-  runOnBaseDirBash "echo '$checkAlgorithmsCode' > /tmp/CheckAlgorithms.java && echo '$cipherListCode' > /tmp/CipherList.java && \
-                    javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list algorithms"
+
+  commandAlgorithms="echo '$checkAlgorithmsCode' > /tmp/CheckAlgorithms.java && echo '$cipherListCode' > /tmp/CipherList.java && javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list algorithms"
+  runOnBaseDirBash "$commandAlgorithms"
+  echo "runOnBaseDirBash $commandAlgorithms" >> $REPORT_DIR/global-stdouterr.log
+
   set -x
 }
 
 function listCryptoProviders() {
   skipIfJreExecution
   set +x
-  runOnBaseDirBash "echo '$checkAlgorithmsCode' > /tmp/CheckAlgorithms.java && echo '$cipherListCode' > /tmp/CipherList.java && \
-                    javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list providers"
+
+  commandProviders="echo '$checkAlgorithmsCode' > /tmp/CheckAlgorithms.java && echo '$cipherListCode' > /tmp/CipherList.java && javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list providers"
+  runOnBaseDirBash "$commandProviders"
+  echo "runOnBaseDirBash $commandProviders" >> $REPORT_DIR/global-stdouterr.log
+
   set -x
 }

--- a/containersQa/testlib.bash
+++ b/containersQa/testlib.bash
@@ -992,8 +992,8 @@ function listCryptoAlgorithms() {
   skipIfJreExecution
   set +x
   commandAlgorithms="echo '$checkAlgorithmsCode' > /tmp/CheckAlgorithms.java && echo '$cipherListCode' > /tmp/CipherList.java && javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list algorithms"
-  runOnBaseDirBash "$commandAlgorithms" 2>&1| tee $REPORT_FILE
   echo "runOnBaseDirBash $commandAlgorithms"
+  runOnBaseDirBash "$commandAlgorithms" 2>&1| tee $REPORT_FILE
   set -x
 }
 
@@ -1001,7 +1001,7 @@ function listCryptoProviders() {
   skipIfJreExecution
   set +x
   commandProviders="echo '$checkAlgorithmsCode' > /tmp/CheckAlgorithms.java && echo '$cipherListCode' > /tmp/CipherList.java && javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list providers"
-  runOnBaseDirBash "$commandProviders" 2>&1| tee $REPORT_FILE
   echo "runOnBaseDirBash $commandProviders"
+  runOnBaseDirBash "$commandProviders" 2>&1| tee $REPORT_FILE
   set -x
 }

--- a/containersQa/testlib.bash
+++ b/containersQa/testlib.bash
@@ -990,12 +990,16 @@ function validateManualSettingFipsWithNoCrash() {
 
 function listCryptoAlgorithms() {
   skipIfJreExecution
+  set +x
   runOnBaseDirBash "echo '$checkAlgorithmsCode' > /tmp/CheckAlgorithms.java && echo '$cipherListCode' > /tmp/CipherList.java && \
                     javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list algorithms"
+  set -x
 }
 
 function listCryptoProviders() {
   skipIfJreExecution
+  set +x
   runOnBaseDirBash "echo '$checkAlgorithmsCode' > /tmp/CheckAlgorithms.java && echo '$cipherListCode' > /tmp/CipherList.java && \
                     javac -d /tmp /tmp/CheckAlgorithms.java /tmp/CipherList.java && java -cp /tmp CheckAlgorithms list providers"
+  set -x
 }


### PR DESCRIPTION
I added `set +x` command to the `listCryptoAlgorithms()` and `listCryptoProviders()` methods, so the output in `report.txt` files contains less garbage. 

Before these changes, the file contained whole Java classes (which were saved into variables, so when the whole command was printed, the Java classes were there). Now, it mostly just contains the desired result.