### PR TITLE
[OPENJDK-3667]Add a test for validing the removal of the hsperfdata folder from tmp after build completion.

### DIFF
--- a/containersQa/216_s2iHsperfdataDirRemovalBuild.sh
+++ b/containersQa/216_s2iHsperfdataDirRemovalBuild.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+set -o pipefail
+
+## resolve folder of this script, following all symlinks,
+## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+readonly SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+
+source $SCRIPT_DIR/testlib.bash
+
+parseArguments "$@"
+processArguments
+setup
+s2ihsperfdataDirRemovalBuild   2>&1| tee  $REPORT_FILE

--- a/containersQa/217_s2iHsperfdataDirRemovalCheck.sh
+++ b/containersQa/217_s2iHsperfdataDirRemovalCheck.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -ex
+set -o pipefail
+
+## resolve folder of this script, following all symlinks,
+## http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+SCRIPT_SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SCRIPT_SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+  SCRIPT_SOURCE="$(readlink "$SCRIPT_SOURCE")"
+  # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+  [[ $SCRIPT_SOURCE != /* ]] && SCRIPT_SOURCE="$SCRIPT_DIR/$SCRIPT_SOURCE"
+done
+readonly SCRIPT_DIR="$( cd -P "$( dirname "$SCRIPT_SOURCE" )" && pwd )"
+
+source $SCRIPT_DIR/testlib.bash
+
+parseArguments "$@"
+processArguments
+setup
+s2iHsPerfDataCheck  2>&1| tee  $REPORT_FILE


### PR DESCRIPTION
Test to validate the removal of the hsperfdata from the /tmp folder after build completion.
Relates to:
https://github.com/rh-openjdk/redhat-openjdk-containers/commit/7b635be6a7d85f552c267dd9f56484efdbffed2f