### PR TITLE
Make podman pull ignore TLS certificate issues

### DIFF
--- a/containersQa/testlib.bash
+++ b/containersQa/testlib.bash
@@ -177,7 +177,11 @@ function getHashFromImageId() {
 }
 
 function pullImage() {
-   $PD_PROVIDER pull $JDK_CONTAINER_IMAGE
+   if [[ "x$PD_PROVIDER" == "xpodman" ]]; then
+       $PD_PROVIDER pull --tls-verify=false $JDK_CONTAINER_IMAGE
+   else
+       $PD_PROVIDER pull $JDK_CONTAINER_IMAGE
+   fi
 }
 
 function checkImage() {


### PR DESCRIPTION
Add a `--tls-verify=false` to `podman pull` to make it ignore TLS certificate expiration.