### PR TITLE
Adapt tests for Maven 3.9

### DIFF
--- a/containersQa/testlib.bash
+++ b/containersQa/testlib.bash
@@ -810,9 +810,17 @@ function checkHardcodedMaven() {
   cat $(getOldMvnVersionLog)
   cat $(getOldMvnVersionLog) | grep "Apache Maven"
   if [ `getOsMajor` -eq 9 ] ; then
-    cat $(getOldMvnVersionLog) | grep "Apache Maven 3.8"
+    if [[ $OTOOL_JDK_VERSION -ne 11 ]]; then
+       cat $(getOldMvnVersionLog) | grep "Apache Maven 3.9"
+    else
+       cat $(getOldMvnVersionLog) | grep "Apache Maven 3.8"
+    fi
   elif [ `getOsMajor` -eq 8 ] ; then
-    cat $(getOldMvnVersionLog) | grep "Apache Maven 3.8"
+    if [[ $OTOOL_JDK_VERSION -ne 11 ]]; then
+       cat $(getOldMvnVersionLog) | grep "Apache Maven 3.9"
+    else
+       cat $(getOldMvnVersionLog) | grep "Apache Maven 3.8"
+    fi
   elif [ `getOsMajor` -eq 7 ] ; then
     cat $(getOldMvnVersionLog) | grep "Apache Maven 3.6"
   else


### PR DESCRIPTION
@vieiro please confirm that JDK 11 doesn't use Maven 3.9 in their containers and therefore it has to be excluded, thanks :) 