### PR TITLE
Remove Maven 3.9 from UBI 8 config

### DIFF
--- a/containersQa/testlib.bash
+++ b/containersQa/testlib.bash
@@ -816,11 +816,7 @@ function checkHardcodedMaven() {
        cat $(getOldMvnVersionLog) | grep "Apache Maven 3.8"
     fi
   elif [ `getOsMajor` -eq 8 ] ; then
-    if [[ $OTOOL_JDK_VERSION -ne 11 ]]; then
-       cat $(getOldMvnVersionLog) | grep "Apache Maven 3.9"
-    else
-       cat $(getOldMvnVersionLog) | grep "Apache Maven 3.8"
-    fi
+    cat $(getOldMvnVersionLog) | grep "Apache Maven 3.8"
   elif [ `getOsMajor` -eq 7 ] ; then
     cat $(getOldMvnVersionLog) | grep "Apache Maven 3.6"
   else


### PR DESCRIPTION
The maven was upgraded only on UBI9, so for UBI8, the expected maven is still 3.8